### PR TITLE
users/show_other.html.erbからMemory一覧を削除。

### DIFF
--- a/app/views/users/show_other.html.erb
+++ b/app/views/users/show_other.html.erb
@@ -15,7 +15,6 @@
       </div>
       <div class="d-md-block col-md-12 col-lg-12 py-1 py-md-3">
         <% if @other_user != @user %>
-          <%= link_to "Memory一覧", show_other_index_memory_path(@other_user.id), class: "btn btn-outline-primary btn-sm py-1 px-5 px-md-3 mb-2" %>
           <%= link_to "お悩み相談一覧", concerns_path, class: "btn btn-outline-info btn-sm py-1 px-5 px-md-2 mb-2" %>
           <%= link_to "オススメ一覧", recommends_path, class: "btn btn-outline-success btn-sm py-1 px-5 px-md-2 mb-2" %>
         <% end %>


### PR DESCRIPTION
users/show_other.html.erbから他のユーザーのMemory一覧を削除。
Memoryは自分の投稿のみ閲覧出来るようバリデーションしているため、他のユーザーのMemory一覧がボタンが不要なので削除。