### PR TITLE
ゲストユーザー機能の実装。

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,4 +28,11 @@ class ApplicationController < ActionController::Base
   def set_user
     @user = current_user
   end
+
+  def check_guest
+    email = resource.email || params[:user][:email].downcase
+    if email == 'guest_user@example.com'
+      redirect_to root_path, notice: "ゲストユーザーの編集・削除はできません。"
+    end
+  end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,34 +1,3 @@
-# frozen_string_literal: true
-
 class Users::PasswordsController < Devise::PasswordsController
-  # GET /resource/password/new
-  # def new
-  #   super
-  # end
-
-  # POST /resource/password
-  # def create
-  #   super
-  # end
-
-  # GET /resource/password/edit?reset_password_token=abcdef
-  # def edit
-  #   super
-  # end
-
-  # PUT /resource/password
-  # def update
-  #   super
-  # end
-
-  # protected
-
-  # def after_resetting_password_path_for(resource)
-  #   super(resource)
-  # end
-
-  # The path used after sending reset password instructions
-  # def after_sending_reset_password_instructions_path_for(resource_name)
-  #   super(resource_name)
-  # end
+  before_action check_guest, only: [:create]
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,51 +1,9 @@
-# frozen_string_literal: true
-
 class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
   before_action :configure_account_update_params, only: [:update]
-
-  # GET /resource/sign_up
-  # def new
-  #   super
-  # end
-
-  # POST /resource
-  # def create
-  #   super
-  # end
-
-  # GET /resource/edit
-  # def edit
-  #   super
-  # end
-
-  # PUT /resource
-  # def update
-  #   super
-  # end
-
-  # DELETE /resource
-  # def destroy
-  #   super
-  # end
-
-  # GET /resource/cancel
-  # Forces the session data which is usually expired after sign
-  # in to be expired now. This is useful if the user wants to
-  # cancel oauth signing in/up in the middle of the process,
-  # removing all OAuth session data.
-  # def cancel
-  #   super
-  # end
+  before_action :check_guest, only: %i(update destroy)
 
   protected
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
-
-  # If you have extra params to permit, append them to the sanitizer.
   def configure_account_update_params
     devise_parameter_sanitizer.permit(:account_update, keys: [:username, :country_code, :job])
   end
@@ -57,14 +15,4 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def update_resource(resource, params)
     resource.update_without_current_password(params)
   end
-
-  # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
-
-  # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,27 +1,9 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
-  # before_action :configure_sign_in_params, only: [:create]
-
-  # GET /resource/sign_in
-  # def new
-  #   super
-  # end
-
-  # POST /resource/sign_in
-  # def create
-  #   super
-  # end
-
-  # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
-
-  # protected
-
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_in_params
-  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
-  # end
+  def new_guest
+    user = User.guest
+    sign_in user
+    redirect_to root_path, notice: "ゲストユーザーとしてログインしました。"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,6 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable #:confirmable
+         :recoverable, :rememberable, :validatable
 
   validates :username, presence: true
   validates :country_code, presence: true
@@ -36,6 +34,13 @@ class User < ApplicationRecord
 
   def already_likes?(recommend)
     likes.exists?(recommend_id: recommend.id)
+  end
+
+  def self.guest
+    find_or_create_by(email: 'guest_user@example.com') do |user|
+      user.password = SecureRandom.urlsafe_base64
+      user.username = "ゲスト"
+    end
   end
 
   mount_uploader :image, ImageUploader

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -41,6 +41,9 @@
         </li>
       <% else %>
         <li class="nav-item d-flex align-items-center">
+          <%= link_to "ゲスト(閲覧用)", users_guest_sign_in_path, method: :post, class:"nav-link" %>
+        </li>
+        <li class="nav-item d-flex align-items-center">
           <%= link_to "ログイン", new_user_session_path, class:"nav-link" %>
         </li>
         <li class="nav-item d-flex align-items-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,11 +4,11 @@ Rails.application.routes.draw do
     :controllers => {
       :registrations => 'users/registrations',
       :sessions => 'users/sessions',
+      passwords: 'users/passwords'
     }
 
-  devise_scope :users do
-    get "sign_in", :to => "users/sessions#new"
-    get "sign_out", :to => "users/sessions#destroy"
+  devise_scope :user do
+    post "users/guest_sign_in", to: "users/sessions#new_guest"
   end
 
   resources :concerns do


### PR DESCRIPTION
ゲストユーザー機能を追加。
ヘッダーにあるゲスト(閲覧用)をクリックするとゲストとしてログインすることが出来ます。
ゲストとしてログインした場合、ゲストアカウントの編集・削除を行うことはできません。
仮に編集ボタン・削除ボタンを押した場合、トップページへリダイレクトされ画面上に"ゲストユーザーの編集・削除はできません。"と表示されます。
